### PR TITLE
Avoid using non-standard `originalTarget`

### DIFF
--- a/src/components/Modals.svelte
+++ b/src/components/Modals.svelte
@@ -65,7 +65,7 @@
   $: modalChanged($modals);
 
   function onClickOutside(e) {
-    if (close.onClickOutside && this === e.originalTarget) {
+    if (close.onClickOutside && this === e.target) {
       closeModal();
     }
   }


### PR DESCRIPTION
As `event.originalTarget` is non-standard (cf [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Event/originalTarget)) I think it's better to use `event.target` here.

With Chrome I get `e.originalTarget === undefined`.